### PR TITLE
Removed unnecessary line from plugin.yml

### DIFF
--- a/resources/plugin.yml
+++ b/resources/plugin.yml
@@ -7,7 +7,6 @@ commands:
   ench:
     description: Gives basic access; /ench help.
     usage: /ench
-    default: true
 permissions:
   enchplus.enchant.get:
     description: Allows for obtaining custom enchantments


### PR DESCRIPTION
According to the Spigot and the Bukkit wikis, 'default' only applies to permissions and not for commands.

https://www.spigotmc.org/wiki/plugin-yml/#commands
https://bukkit.gamepedia.com/Plugin_YAML