### PR TITLE
Fixed Tracer: Now only works more than 15 blocks away

### DIFF
--- a/src/main/java/de/geolykt/enchantments_plus/enchantments/Tracer.java
+++ b/src/main/java/de/geolykt/enchantments_plus/enchantments/Tracer.java
@@ -80,7 +80,7 @@ public class Tracer extends CustomEnchantment {
         if (!source.getLocation().getWorld().equals(shooterEntity.getLocation().getWorld())) {
             return null; // the shooter switched worlds in the meantime
         }
-        if (source.getLocation().distanceSquared(shooterEntity.getLocation()) > 225) {
+        if (source.getLocation().distanceSquared(shooterEntity.getLocation()) < 225) {
             return null; // Arrow has not yet travelled far enough
         }
         closestEntity = null; // in case it was not null, but otherwise invalid


### PR DESCRIPTION
Let "dist" be the distance between the arrow and the shooter.

Previous behavior:
If dist^2 > 225, NOT HOMING
If dist^2 < 225, HOMING
So homing arrows only work if the shooter stays within 15 blocks of the homing arrow.

New behavior:
If dist^2 < 225, NOT HOMING
If dist^2 > 225, HOMING
So homing arrows only work if the shooter stays more than 15 blocks away from the homing arrow.

Based on the comments, this is the intended behavior.
Also, you can check that it doesn't work (right now) because if you stand at point-blank range and shoot something, the arrow will immediately try to hit it.